### PR TITLE
Remove broken and unnecessary outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,8 @@ This module provisions a dataset and a list of tables with associated JSON schem
 
 | Name | Description |
 |------|-------------|
-| added\_udfs | List of UDFs utility functions added. |
 | bigquery\_dataset | Bigquery dataset resource. |
 | bigquery\_tables | Map of bigquery table resources being provisioned. |
-| dataset\_labels | Key value pairs in a map for dataset labels |
-| dataset\_project | Project where the dataset and table are created |
-| table\_id | Unique id for the table being provisioned |
-| table\_labels | Key value pairs in a map for table labels |
-| table\_name | Friendly name for the table being provisioned |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ This module provisions a dataset and a list of tables with associated JSON schem
 |------|-------------|
 | bigquery\_dataset | Bigquery dataset resource. |
 | bigquery\_tables | Map of bigquery table resources being provisioned. |
+| project | Project where the dataset and tables are created |
+| table\_ids | Unique id for the table being provisioned |
+| table\_names | Unique id for the table being provisioned |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,24 @@ output "bigquery_tables" {
   value       = google_bigquery_table.main
   description = "Map of bigquery table resources being provisioned."
 }
+
+output "project" {
+  value       = google_bigquery_dataset.main.project
+  description = "Project where the dataset and tables are created"
+}
+
+output "table_ids" {
+  value = [
+    for table in google_bigquery_table.main :
+    table.table_id
+  ]
+  description = "Unique id for the table being provisioned"
+}
+
+output "table_names" {
+  value = [
+    for table in google_bigquery_table.main :
+    table.friendly_name
+  ]
+  description = "Unique id for the table being provisioned"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,33 +23,3 @@ output "bigquery_tables" {
   value       = google_bigquery_table.main
   description = "Map of bigquery table resources being provisioned."
 }
-
-output "dataset_project" {
-  value       = google_bigquery_dataset.main.project
-  description = "Project where the dataset and table are created"
-}
-
-output "table_id" {
-  value       = google_bigquery_table.main.*.id
-  description = "Unique id for the table being provisioned"
-}
-
-output "table_name" {
-  value       = google_bigquery_table.main.*.friendly_name
-  description = "Friendly name for the table being provisioned"
-}
-
-output "dataset_labels" {
-  value       = google_bigquery_dataset.main.labels
-  description = "Key value pairs in a map for dataset labels"
-}
-
-output "table_labels" {
-  value       = google_bigquery_table.main.*.labels
-  description = "Key value pairs in a map for table labels"
-}
-
-output "added_udfs" {
-  description = "List of UDFs utility functions added."
-  value       = module.udfs.added_udfs
-}


### PR DESCRIPTION
I didn't bother fixing them was I believe they were accidentally re-added.

See the history of outputs.tf: https://github.com/terraform-google-modules/terraform-google-bigquery/commits/master/outputs.tf

In particular:

- Nov 9 which has a lot of outputs: 9c8cff9#diff-c09d00f135e3672d079ff6e0556d957d
- Dec 2 which removed the extra outputs: 9dc3d31#diff-c09d00f135e3672d079ff6e0556d957d
- Dec 15 which added them back accidentally: c485f77#diff-c09d00f135e3672d079ff6e0556d957d

I would prefer the simpler approach of not adding all these ouputs since we return the list of tables the user can easily compute these values if they care to. But if you feel we should kep some of these I am happy to re-add.

dataset project output was removed  because there doesn't seem to be any benefit from this output.

One could just do:
module.bq.bigquery_dataset.project instead (versus module.bq.dataset_project).

Fix #45 