### PR TITLE
Add support for access

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This module provisions a dataset and a list of tables with associated JSON schem
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| access | An array of objects that define dataset access for one or more entities. | any | `<list>` | no |
 | add\_udfs | Whether or not to add a handful of UDF utilities to your dataset. | string | `"false"` | no |
 | dataset\_id | Unique ID for the dataset being provisioned. | string | n/a | yes |
 | dataset\_labels | Key value pairs in a map for dataset labels | map(string) | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,18 @@ resource "google_bigquery_dataset" "main" {
   default_table_expiration_ms = var.default_table_expiration_ms
   project                     = var.project_id
   labels                      = var.dataset_labels
+
+  dynamic "access" {
+    for_each = var.access
+    content {
+      role = access.value.role
+
+      domain         = lookup(access.value, "domain", null)
+      group_by_email = lookup(access.value, "group_by_email", null)
+      user_by_email  = lookup(access.value, "user_by_email", null)
+      special_group  = lookup(access.value, "special_group", null)
+    }
+  }
 }
 
 resource "google_bigquery_table" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,23 @@ variable "dataset_labels" {
   type        = map(string)
 }
 
+# Format: list(objects)
+# domain: A domain to grant access to.
+# group_by_email: An email address of a Google Group to grant access to.
+# user_by_email:  An email address of a user to grant access to.
+# group_by_email: An email address of a Google Group to grant access to.
+# special_group: A special group to grant access to.
+variable "access" {
+  description = "An array of objects that define dataset access for one or more entities."
+  type        = any
+
+  # At least one owner access is required.
+  default = [{
+    role          = "roles/bigquery.dataOwner"
+    special_group = "projectOwners"
+  }]
+}
+
 variable "tables" {
   description = "A list of objects which include table_id, schema, clustering, time_partitioning, expiration_time and labels."
   default     = []


### PR DESCRIPTION
Also set a better default (a single owner which is projectOwners). The defaults of BQ are not very good which is why I made this PR to begin with as we would like to use this module for our e2e solutions. The default BQ adds the calling user as an owner on the dataset which is a big no-no for us (access should only be granted via explicit groups/service accounts or inheritance). This default is much more secure and in line with how other GCP resources work.

I thought it would be ok to improve the default for CFT as better defaults was one of the goals. But if you prefer to avoid diff I can just set this to null as default which shouldn't need a new release.

Fix #12 