### PR TITLE
Rename vars to be more consistent with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ This module provisions a dataset and a list of tables with associated JSON schem
 |------|-------------|:----:|:-----:|:-----:|
 | add\_udfs | Whether or not to add a handful of UDF utilities to your dataset. | string | `"false"` | no |
 | dataset\_id | Unique ID for the dataset being provisioned. | string | n/a | yes |
-| dataset\_labels | Key value pairs in a map for dataset labels | map(string) | n/a | yes |
-| dataset\_name | Friendly name for the dataset being provisioned. | string | n/a | yes |
 | default\_table\_expiration\_ms | TTL of tables using the dataset in MS | string | `"null"` | no |
 | description | Dataset description. | string | n/a | yes |
+| friendly\_name | Friendly name for the dataset being provisioned. | string | n/a | yes |
+| labels | Key value pairs in a map for dataset labels | map(string) | n/a | yes |
 | location | The regional location for the dataset only US and EU are allowed in module | string | `"US"` | no |
 | project\_id | Project where the dataset and table are created | string | n/a | yes |
 | tables | A list of objects which include table_id, schema, clustering, time_partitioning, expiration_time and labels. | object | `<list>` | no |

--- a/examples/basic_bq/main.tf
+++ b/examples/basic_bq/main.tf
@@ -15,12 +15,12 @@
  */
 
 module "bigquery" {
-  source         = "../.."
-  dataset_id     = "foo"
-  dataset_name   = "foo"
-  description    = "some description"
-  project_id     = var.project_id
-  location       = "US"
-  tables         = var.tables
-  dataset_labels = var.dataset_labels
+  source        = "../.."
+  dataset_id    = "foo"
+  friendly_name = "foo"
+  description   = "some description"
+  project_id    = var.project_id
+  location      = "US"
+  tables        = var.tables
+  labels        = var.dataset_labels
 }

--- a/examples/multiple_tables/main.tf
+++ b/examples/multiple_tables/main.tf
@@ -17,12 +17,12 @@
 module "bigquery" {
   source                      = "../.."
   dataset_id                  = "foo"
-  dataset_name                = "foo"
+  friendly_name               = "foo"
   description                 = "some description"
   default_table_expiration_ms = var.default_table_expiration_ms
   project_id                  = var.project_id
   location                    = "US"
   tables                      = var.tables
-  dataset_labels              = var.dataset_labels
+  labels                      = var.dataset_labels
   add_udfs                    = true
 }

--- a/main.tf
+++ b/main.tf
@@ -20,13 +20,13 @@ locals {
 
 resource "google_bigquery_dataset" "main" {
   dataset_id    = var.dataset_id
-  friendly_name = var.dataset_name
+  friendly_name = var.friendly_name
   description   = var.description
   location      = var.location
 
   default_table_expiration_ms = var.default_table_expiration_ms
   project                     = var.project_id
-  labels                      = var.dataset_labels
+  labels                      = var.labels
 }
 
 resource "google_bigquery_table" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "dataset_id" {
   description = "Unique ID for the dataset being provisioned."
 }
 
-variable "dataset_name" {
+variable "friendly_name" {
   description = "Friendly name for the dataset being provisioned."
 }
 
@@ -40,7 +40,7 @@ variable "project_id" {
   description = "Project where the dataset and table are created"
 }
 
-variable "dataset_labels" {
+variable "labels" {
   description = "Key value pairs in a map for dataset labels"
   type        = map(string)
 }


### PR DESCRIPTION
This is a very optional PR but would be a nice-to have if we make a new major release.

Should we also follow the rename of expiration to default_table_expiration_ms as done in https://github.com/terraform-google-modules/terraform-google-bigquery/blob/master/docs/upgrading_to_bigquery_v3.0.md for greater consistency?