### PR TITLE
Switch default access to use legacy role

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "access" {
 
   # At least one owner access is required.
   default = [{
-    role          = "roles/bigquery.dataOwner"
+    role          = "OWNER"
     special_group = "projectOwners"
   }]
 }


### PR DESCRIPTION
Per https://github.com/terraform-providers/terraform-provider-google/issues/5350#issuecomment-607533636 we will keep seeing diffs on every apply if we set an IAM role here as the bigquery API always returns legacy role.

NOTE: This does *not* cause a breaking change and in fact will prevent users from seeing an unexpected diff if using the BQ module with access unset.