### PR TITLE
fix: Map dataEditor to WRITER role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
   tables = { for table in var.tables : table["table_id"] => table }
   iam_to_primitive = {
     "roles/bigquery.dataOwner" : "OWNER"
-    "roles/bigquery.dataEditor" : "EDITOR"
+    "roles/bigquery.dataEditor" : "WRITER"
     "roles/bigquery.dataViewer" : "READER"
   }
 }


### PR DESCRIPTION
Reverts terraform-google-modules/terraform-google-bigquery#67, fixes #65