### PR TITLE
fix: Use fully scoped keys for views in Terraform

### DIFF
--- a/modules/authorization/main.tf
+++ b/modules/authorization/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   roles = { for role in var.roles : role["role"] => role }
-  views = { for view in var.authorized_views : view["table_id"] => view }
+  views = { for view in var.authorized_views : "${view["project_id"]}_${view["dataset_id"]}_${view["table_id"]}" => view }
 
   iam_to_primitive = {
     "roles/bigquery.dataOwner" : "OWNER"
@@ -32,7 +32,7 @@ resource "google_bigquery_dataset_access" "authorized_view" {
   view {
     project_id = each.value.project_id
     dataset_id = each.value.dataset_id
-    table_id   = each.key
+    table_id   = each.value.table_id
   }
 }
 


### PR DESCRIPTION
We might want to create multiple tables with the same name in different datasets, so we need to include the full info for the Terraform state config to not be broken.

Note: this change will recreate view authorizations, but is ultimately a no-op so we can safely include in a minor release.