### PR TITLE
It allows terraform 0.13.0-rc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ docker_test_cleanup:
 docker_test_integration:
 	docker run --rm -it \
 		-e SERVICE_ACCOUNT_JSON \
-		-e TF_VAR_project_id \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_integration.sh

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ docker_test_cleanup:
 docker_test_integration:
 	docker run --rm -it \
 		-e SERVICE_ACCOUNT_JSON \
+		-e TF_VAR_project_id \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_integration.sh

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ This module provisions a dataset and a list of tables with associated JSON schem
 | dataset\_labels | Key value pairs in a map for dataset labels | map(string) | `<map>` | no |
 | dataset\_name | Friendly name for the dataset being provisioned. | string | `"null"` | no |
 | default\_table\_expiration\_ms | TTL of tables using the dataset in MS | number | `"null"` | no |
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"true"` | no |
 | description | Dataset description. | string | `"null"` | no |
 | location | The regional location for the dataset only US and EU are allowed in module | string | `"US"` | no |
 | project\_id | Project where the dataset and table are created | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This module provisions a dataset and a list of tables with associated JSON schem
 | dataset\_labels | Key value pairs in a map for dataset labels | map(string) | `<map>` | no |
 | dataset\_name | Friendly name for the dataset being provisioned. | string | `"null"` | no |
 | default\_table\_expiration\_ms | TTL of tables using the dataset in MS | number | `"null"` | no |
-| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"true"` | no |
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"null"` | no |
 | description | Dataset description. | string | `"null"` | no |
 | location | The regional location for the dataset only US and EU are allowed in module | string | `"US"` | no |
 | project\_id | Project where the dataset and table are created | string | n/a | yes |

--- a/examples/basic_bq/README.md
+++ b/examples/basic_bq/README.md
@@ -6,6 +6,7 @@ The basic_bq example uses the root terraform-google-bigquery module to deploy a 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"null"` | no |
 | project\_id | Project where the dataset and table are created. | string | n/a | yes |
 
 ## Outputs

--- a/examples/basic_bq/main.tf
+++ b/examples/basic_bq/main.tf
@@ -15,12 +15,13 @@
  */
 
 module "bigquery" {
-  source       = "../.."
-  dataset_id   = "foo"
-  dataset_name = "foo"
-  description  = "some description"
-  project_id   = var.project_id
-  location     = "US"
+  source                     = "../.."
+  dataset_id                 = "foo"
+  dataset_name               = "foo"
+  description                = "some description"
+  project_id                 = var.project_id
+  location                   = "US"
+  delete_contents_on_destroy = var.delete_contents_on_destroy
   tables = [
     {
       table_id          = "bar",

--- a/examples/basic_bq/variables.tf
+++ b/examples/basic_bq/variables.tf
@@ -17,3 +17,9 @@
 variable "project_id" {
   description = "Project where the dataset and table are created."
 }
+
+variable "delete_contents_on_destroy" {
+  description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
+  type        = bool
+  default     = null
+}

--- a/examples/basic_view/README.md
+++ b/examples/basic_view/README.md
@@ -9,6 +9,7 @@ This is a common practice for providing limited data in a different dataset.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | default\_table\_expiration\_ms | Default TTL of tables using the dataset in MS. | string | `"null"` | no |
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"null"` | no |
 | table\_dataset\_labels | A mapping of labels to assign to the table. | map(string) | n/a | yes |
 | table\_project\_id | Project where the dataset and table are created. | string | n/a | yes |
 | tables | A list of maps that includes table_id, schema, clustering, time_partitioning, view, expiration_time, labels in each element. | object | `<list>` | no |

--- a/examples/basic_view/main.tf
+++ b/examples/basic_view/main.tf
@@ -16,14 +16,15 @@
 
 
 module "bigquery_tables" {
-  source         = "../.."
-  dataset_id     = "foo"
-  dataset_name   = "foo"
-  description    = "some description"
-  project_id     = var.table_project_id
-  location       = "US"
-  tables         = var.tables
-  dataset_labels = var.table_dataset_labels
+  source                     = "../.."
+  dataset_id                 = "foo"
+  dataset_name               = "foo"
+  description                = "some description"
+  project_id                 = var.table_project_id
+  location                   = "US"
+  delete_contents_on_destroy = var.delete_contents_on_destroy
+  tables                     = var.tables
+  dataset_labels             = var.table_dataset_labels
 
   # we provide the access control separately with another module, see bottom.
   # Authorization module has the capability of authorizing views
@@ -32,14 +33,15 @@ module "bigquery_tables" {
 }
 
 module "bigquery_views_without_pii" {
-  source         = "../.."
-  dataset_id     = "${module.bigquery_tables.bigquery_dataset.dataset_id}_view_without_pii" # this creates a dependency so that we have the tables first
-  dataset_name   = "foo view"
-  description    = "some description"
-  project_id     = var.view_project_id
-  location       = "US"
-  views          = var.views
-  dataset_labels = var.view_dataset_labels
+  source                     = "../.."
+  dataset_id                 = "${module.bigquery_tables.bigquery_dataset.dataset_id}_view_without_pii" # this creates a dependency so that we have the tables first
+  dataset_name               = "foo view"
+  description                = "some description"
+  project_id                 = var.view_project_id
+  delete_contents_on_destroy = var.delete_contents_on_destroy
+  location                   = "US"
+  views                      = var.views
+  dataset_labels             = var.view_dataset_labels
 
   access = [
     {

--- a/examples/basic_view/terraform.tfvars
+++ b/examples/basic_view/terraform.tfvars
@@ -1,4 +1,5 @@
-table_project_id = "example-table-project"
+delete_contents_on_destroy = true
+table_project_id           = "example-table-project"
 table_dataset_labels = {
   env      = "dev"
   billable = "true"

--- a/examples/basic_view/variables.tf
+++ b/examples/basic_view/variables.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+variable "delete_contents_on_destroy" {
+  description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
+  type        = bool
+  default     = null
+}
+
 variable "default_table_expiration_ms" {
   description = "Default TTL of tables using the dataset in MS."
   default     = null

--- a/examples/multiple_tables/README.md
+++ b/examples/multiple_tables/README.md
@@ -10,6 +10,7 @@ This example is a good reference to understand and test the module usage.
 |------|-------------|:----:|:-----:|:-----:|
 | dataset\_labels | A mapping of labels to assign to the table. | map(string) | n/a | yes |
 | default\_table\_expiration\_ms | Default TTL of tables using the dataset in MS. | string | `"null"` | no |
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"null"` | no |
 | project\_id | Project where the dataset and table are created. | string | n/a | yes |
 | tables | A list of maps that includes table_id, schema, clustering, time_partitioning, expiration_time, labels in each element. | object | `<list>` | no |
 

--- a/examples/multiple_tables/main.tf
+++ b/examples/multiple_tables/main.tf
@@ -19,6 +19,7 @@ module "bigquery" {
   dataset_id                  = "foo"
   dataset_name                = "foo"
   description                 = "some description"
+  delete_contents_on_destroy  = var.delete_contents_on_destroy
   default_table_expiration_ms = var.default_table_expiration_ms
   project_id                  = var.project_id
   location                    = "US"

--- a/examples/multiple_tables/terraform.tfvars
+++ b/examples/multiple_tables/terraform.tfvars
@@ -1,4 +1,5 @@
 project_id                  = "example-project"
+delete_contents_on_destroy  = true
 default_table_expiration_ms = 3600000
 dataset_labels = {
   env      = "dev"

--- a/examples/multiple_tables/variables.tf
+++ b/examples/multiple_tables/variables.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+variable "delete_contents_on_destroy" {
+  description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
+  type        = bool
+  default     = null
+}
+
 variable "default_table_expiration_ms" {
   description = "Default TTL of tables using the dataset in MS."
   default     = null

--- a/main.tf
+++ b/main.tf
@@ -26,12 +26,11 @@ locals {
 }
 
 resource "google_bigquery_dataset" "main" {
-  dataset_id    = var.dataset_id
-  friendly_name = var.dataset_name
-  description   = var.description
+  dataset_id                  = var.dataset_id
+  friendly_name               = var.dataset_name
+  description                 = var.description
+  location                    = var.location
   delete_contents_on_destroy  = var.delete_contents_on_destroy
-  location      = var.location
-
   default_table_expiration_ms = var.default_table_expiration_ms
   project                     = var.project_id
   labels                      = var.dataset_labels

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ resource "google_bigquery_dataset" "main" {
   dataset_id    = var.dataset_id
   friendly_name = var.dataset_name
   description   = var.description
+  delete_contents_on_destroy  = var.delete_contents_on_destroy
   location      = var.location
 
   default_table_expiration_ms = var.default_table_expiration_ms

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "description" {
   default     = null
 }
 
+variable "delete_contents_on_destroy" {
+  description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
+  type        = bool
+  default     = true
+}
+
 variable "location" {
   description = "The regional location for the dataset only US and EU are allowed in module"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -31,16 +31,16 @@ variable "description" {
   default     = null
 }
 
-variable "delete_contents_on_destroy" {
-  description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
-  type        = bool
-  default     = true
-}
-
 variable "location" {
   description = "The regional location for the dataset only US and EU are allowed in module"
   type        = string
   default     = "US"
+}
+
+variable "delete_contents_on_destroy" {
+  description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
+  type        = bool
+  default     = null
 }
 
 variable "default_table_expiration_ms" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6"
   required_providers {
     google = "~> 3.0"
   }


### PR DESCRIPTION
The current required Terraform version constrains the use of terraform 0.13.0-rc1 and throws the below error.

```
Error: Unsupported Terraform Core version

  on .terraform/modules/cloud-logging-bigquery/versions.tf line 18, in terraform:
  18:   required_version = "~> 0.12.6"

Module module.cloud-logging-bigquery (from
git::https://github.com/terraform-google-modules/terraform-google-bigquery.git?ref=master)
does not support Terraform version 0.13.0-rc1. To proceed, either choose
another supported Terraform version or update this version constraint. Version
constraints are normally set for good reason, so updating the constraint may
lead to other errors or unexpected behavior.
```

This pull request replaces terraform version pessimistic constraint operator for "greater than" allowing the use of  0.13.0-rc1 

Also, trying to follow the documentation  [Specifying a Required Terraform Version](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version)

"Re-usable modules should constrain only the minimum allowed version, such as >= 0.12.0. This specifies the earliest version that the module is compatible with while leaving the user of the module flexibility to upgrade to newer versions of Terraform without altering the module."

