### PR TITLE
it allows to run terraform 0.13.0-rc1 

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6"
   required_providers {
     google = "~> 3.0"
   }


### PR DESCRIPTION
The current required Terraform version constrains the use of terraform 0.13.0-rc1 and throws the below error.

```
Error: Unsupported Terraform Core version

  on .terraform/modules/cloud-logging-bigquery/versions.tf line 18, in terraform:
  18:   required_version = "~> 0.12.6"

Module module.cloud-logging-bigquery (from
git::https://github.com/terraform-google-modules/terraform-google-bigquery.git?ref=master)
does not support Terraform version 0.13.0-rc1. To proceed, either choose
another supported Terraform version or update this version constraint. Version
constraints are normally set for good reason, so updating the constraint may
lead to other errors or unexpected behaviour.
```

This pull request replaces terraform version pessimistic constraint operator for "greater than" allowing the use of  0.13.0-rc1 

Also, trying to follow the documentation on  [Specifying a Required Terraform Version](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version)

"Re-usable modules should constrain only the minimum allowed version, such as >= 0.12.0. This specifies the earliest version that the module is compatible with while leaving the user of the module flexibility to upgrade to newer versions of Terraform without altering the module."