### PR TITLE
adds default_partition_expiration_ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ This module provisions a dataset and a list of tables with associated JSON schem
 | dataset\_id | Unique ID for the dataset being provisioned. | string | n/a | yes |
 | dataset\_labels | Key value pairs in a map for dataset labels | map(string) | `<map>` | no |
 | dataset\_name | Friendly name for the dataset being provisioned. | string | `"null"` | no |
+| default\_partition\_expiration\_ms | TTL of partitioned tables using the dataset in MS | number | `"null"` | no |
 | default\_table\_expiration\_ms | TTL of tables using the dataset in MS | number | `"null"` | no |
 | delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"null"` | no |
 | description | Dataset description. | string | `"null"` | no |

--- a/main.tf
+++ b/main.tf
@@ -26,14 +26,15 @@ locals {
 }
 
 resource "google_bigquery_dataset" "main" {
-  dataset_id                  = var.dataset_id
-  friendly_name               = var.dataset_name
-  description                 = var.description
-  location                    = var.location
-  delete_contents_on_destroy  = var.delete_contents_on_destroy
-  default_table_expiration_ms = var.default_table_expiration_ms
-  project                     = var.project_id
-  labels                      = var.dataset_labels
+  dataset_id                      = var.dataset_id
+  friendly_name                   = var.dataset_name
+  description                     = var.description
+  location                        = var.location
+  delete_contents_on_destroy      = var.delete_contents_on_destroy
+  default_table_expiration_ms     = var.default_table_expiration_ms
+  default_partition_expiration_ms = var.default_partition_expiration_ms
+  project                         = var.project_id
+  labels                          = var.dataset_labels
 
   dynamic "access" {
     for_each = var.access

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "default_table_expiration_ms" {
   default     = null
 }
 
+variable "default_partition_expiration_ms" {
+  description = "TTL of partitioned tables using the dataset in MS"
+  type        = number
+  default     = null
+}
+
 variable "project_id" {
   description = "Project where the dataset and table are created"
   type        = string


### PR DESCRIPTION
Hello again,
The intention here is to add an optional argument to set the default partition expiration for all partitioned tables in the dataset, in milliseconds.
[Reference](https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html#default_partition_expiration_ms)