### PR TITLE
Fix force table recreation after dataset table list modification with enabled encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,10 +92,10 @@ resource "google_bigquery_table" "main" {
       }
     }
   }
-    
+
   lifecycle {
     ignore_changes = [
-      encryption_configuration, # managed by google_bigquery_dataset.main.default_encryption_configuration
+      encryption_configuration # managed by google_bigquery_dataset.main.default_encryption_configuration
     ]
   }
 }
@@ -116,7 +116,7 @@ resource "google_bigquery_table" "view" {
 
   lifecycle {
     ignore_changes = [
-      encryption_configuration, # managed by google_bigquery_dataset.main.default_encryption_configuration
+      encryption_configuration # managed by google_bigquery_dataset.main.default_encryption_configuration
     ]
   }
 }
@@ -171,7 +171,7 @@ resource "google_bigquery_table" "external_table" {
 
   lifecycle {
     ignore_changes = [
-      encryption_configuration, # managed by google_bigquery_dataset.main.default_encryption_configuration
+      encryption_configuration # managed by google_bigquery_dataset.main.default_encryption_configuration
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,12 @@ resource "google_bigquery_table" "main" {
       }
     }
   }
+    
+  lifecycle {
+    ignore_changes = [
+      encryption_configuration, # managed by google_bigquery_dataset.main.default_encryption_configuration
+    ]
+  }
 }
 
 resource "google_bigquery_table" "view" {
@@ -106,6 +112,12 @@ resource "google_bigquery_table" "view" {
   view {
     query          = each.value["query"]
     use_legacy_sql = each.value["use_legacy_sql"]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      encryption_configuration, # managed by google_bigquery_dataset.main.default_encryption_configuration
+    ]
   }
 }
 
@@ -155,5 +167,11 @@ resource "google_bigquery_table" "external_table" {
         source_uri_prefix = hive_partitioning_options.value["source_uri_prefix"]
       }
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      encryption_configuration, # managed by google_bigquery_dataset.main.default_encryption_configuration
+    ]
   }
 }


### PR DESCRIPTION
- Fixes #120 
- Added ignore ` encryption` property for tables resource due to centralized encryption property in the dataset;
- Prevents existing tables recreation;