### PR TITLE
fix: Add project id to the resource configuration

### DIFF
--- a/modules/scheduled_queries/main.tf
+++ b/modules/scheduled_queries/main.tf
@@ -27,6 +27,7 @@ resource "google_project_iam_member" "bq_transfer_permission" {
 resource "google_bigquery_data_transfer_config" "query_config" {
   for_each = { for i in var.queries : i.name => i }
 
+  project                   = var.project_id
   display_name              = each.value.name
   location                  = lookup(each.value, "location", null)
   data_source_id            = each.value.data_source_id


### PR DESCRIPTION
Add missed `project_id` value, so not only the default project can be used.