### PR TITLE
Workaround issue causing permanent diff in access list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,10 +53,12 @@ resource "google_bigquery_dataset" "main" {
       # Thus, do the conversion between IAM to primitive role here to prevent the diff.
       role = lookup(local.iam_to_primitive, access.value.role, access.value.role)
 
-      domain         = lookup(access.value, "domain", null)
-      group_by_email = lookup(access.value, "group_by_email", null)
-      user_by_email  = lookup(access.value, "user_by_email", null)
-      special_group  = lookup(access.value, "special_group", null)
+      # Additionally, using null as a default value would lead to a permanant diff
+      # See https://github.com/hashicorp/terraform-provider-google/issues/4085#issuecomment-516923872
+      domain         = lookup(access.value, "domain", "")
+      group_by_email = lookup(access.value, "group_by_email", "")
+      user_by_email  = lookup(access.value, "user_by_email", "")
+      special_group  = lookup(access.value, "special_group", "")
     }
   }
 }


### PR DESCRIPTION
Hi Everyone,

For the past few months, my team and I have been suffering from large permanent diffs in our `access` list when we use this module. Today I finally got sick of it, and went searching for a solution. In my search I encountered [this workaround](https://github.com/hashicorp/terraform-provider-google/issues/4085#issuecomment-516923872) which has solved the problem for us locally. I realize that this isn't a perfect fix for the root cause issue here, but it does make for a much better user experience.

I figured that it would make sense to push this fix upstream so that users of this module won't have to experience this issues.

If it doesn't make sense to you all to merge this into the module itself, here is an uglier workaround that we are using locally:

```
locals {
  default_access = [
    {
      "role" : "roles/bigquery.dataViewer",
      "user_by_email" : "some_user@gmail.com",
    },
    {
      "role" : "roles/bigquery.dataViewer",
      "group_by_email" : "some_group@gmail.com",
    },
  ]
}

module "my_dataset" {
  source  = "terraform-google-modules/bigquery/google"
  ...etc...
  access = [for entry in local.default_access:
                      merge({
                        "user_by_email": "",
                        "group_by_email": "",
                        "special_group": "",
                        "domain": "",
                      }, entry)]
}
```

Thanks!
Matthew