### PR TITLE
Add "description" attribute to BQ tables

### DIFF
--- a/examples/basic_bq/main.tf
+++ b/examples/basic_bq/main.tf
@@ -29,6 +29,7 @@ module "bigquery" {
       time_partitioning  = null,
       range_partitioning = null,
       expiration_time    = 2524604400000, # 2050/01/01
+      description        = "some description"
       clustering         = [],
       labels = {
         env      = "devops"

--- a/examples/basic_view/main.tf
+++ b/examples/basic_view/main.tf
@@ -70,9 +70,10 @@ module "authorization" {
   authorized_views = [
     for view in var.views :
     {
-      project_id = var.view_project_id,
-      dataset_id = module.bigquery_views_without_pii.bigquery_dataset.dataset_id,
-      table_id   = view.view_id
+      project_id  = var.view_project_id,
+      dataset_id  = module.bigquery_views_without_pii.bigquery_dataset.dataset_id,
+      table_id    = view.view_id,
+      description = view.description
     }
   ]
 }

--- a/examples/basic_view/variables.tf
+++ b/examples/basic_view/variables.tf
@@ -57,6 +57,7 @@ variable "tables" {
     }),
     expiration_time = string,
     labels          = map(string),
+    description     = string,
   }))
 }
 
@@ -80,5 +81,6 @@ variable "views" {
     query          = string,
     use_legacy_sql = bool,
     labels         = map(string),
+    description    = string,
   }))
 }

--- a/examples/multiple_tables/main.tf
+++ b/examples/multiple_tables/main.tf
@@ -33,6 +33,7 @@ module "bigquery" {
         require_partition_filter = false,
         expiration_ms            = null,
       },
+      description        = "some description",
       range_partitioning = null,
       expiration_time    = null,
       clustering         = ["fullVisitorId", "visitId"],
@@ -73,6 +74,7 @@ module "bigquery" {
       source_format         = "CSV"
       schema                = null
       expiration_time       = 2524604400000 # 2050/01/01
+      description           = ""
       labels = {
         env      = "devops"
         billable = "true"
@@ -101,6 +103,7 @@ module "bigquery" {
       source_format         = "CSV"
       schema                = null
       expiration_time       = 2524604400000 # 2050/01/01
+      description           = ""
       labels = {
         env      = "devops"
         billable = "true"
@@ -129,6 +132,7 @@ module "bigquery" {
       source_format         = "GOOGLE_SHEETS"
       schema                = null
       expiration_time       = 2524604400000 # 2050/01/01
+      description           = ""
       labels = {
         env      = "devops"
         billable = "true"

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ resource "google_bigquery_table" "main" {
   schema              = each.value["schema"]
   clustering          = each.value["clustering"]
   expiration_time     = each.value["expiration_time"]
+  description         = each.value["description"]
   project             = var.project_id
   deletion_protection = var.deletion_protection
 
@@ -108,6 +109,7 @@ resource "google_bigquery_table" "view" {
   friendly_name       = each.key
   table_id            = each.key
   labels              = each.value["labels"]
+  description         = each.value["description"]
   project             = var.project_id
   deletion_protection = false
 
@@ -131,6 +133,7 @@ resource "google_bigquery_table" "materialized_view" {
   labels              = each.value["labels"]
   clustering          = each.value["clustering"]
   expiration_time     = each.value["expiration_time"]
+  description         = each.value["description"]
   project             = var.project_id
   deletion_protection = false
 
@@ -176,6 +179,7 @@ resource "google_bigquery_table" "external_table" {
   table_id            = each.key
   labels              = each.value["labels"]
   expiration_time     = each.value["expiration_time"]
+  description         = each.value["description"]
   project             = var.project_id
   deletion_protection = var.deletion_protection
 

--- a/test/integration/full/controls/big_query.rb
+++ b/test/integration/full/controls/big_query.rb
@@ -32,12 +32,14 @@ describe google_bigquery_table(project: "#{project_id}", dataset: "#{dataset_nam
   it { should exist }
   its('friendly_name') { should eq "#{tables[:foo][:friendly_name]}" }
   its('time_partitioning.type') { should eq 'DAY' }
+  its('description') { should eq "#{tables[:foo][:description]}" }
   its('clustering') { should_not be nil }
 end
 
 describe google_bigquery_table(project: "#{project_id}", dataset: "#{dataset_name}", name: "#{tables[:bar][:friendly_name]}") do
   it { should exist }
   its('friendly_name') { should eq "#{tables[:bar][:friendly_name]}" }
+  its('description') { should eq "#{tables[:bar][:description]}" }
   its('time_partitioning.type') { should be nil }
   its('clustering') { should be nil }
 end
@@ -45,6 +47,7 @@ end
 describe google_bigquery_table(project: "#{project_id}", dataset: "#{dataset_name}", name: "#{external_tables[:csv_example][:friendly_name]}") do
   it { should exist }
   its('friendly_name') { should eq "#{external_tables[:csv_example][:friendly_name]}" }
+  its('description') { should eq "#{tables[:csv_example][:description]}" }
   its('time_partitioning.type') { should be nil }
   its('clustering') { should be nil }
   its('type') { should eq "EXTERNAL" }

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,7 @@ variable "tables" {
     }),
     expiration_time = string,
     labels          = map(string),
+    description     = string,
   }))
 }
 
@@ -122,6 +123,7 @@ variable "views" {
     query          = string,
     use_legacy_sql = bool,
     labels         = map(string),
+    description    = string,
   }))
 }
 
@@ -150,6 +152,7 @@ variable "materialized_views" {
     }),
     expiration_time = string,
     labels          = map(string),
+    description     = string,
   }))
 }
 
@@ -183,6 +186,7 @@ variable "external_tables" {
     }),
     expiration_time = string,
     labels          = map(string),
+    description     = string,
   }))
 }
 


### PR DESCRIPTION
Hello,

this PR adds a [description](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#description) argument to big query tables.

I find description quite useful, but sadly it's breaking change becacuse of the nature of terraform objects. This could be avoided using optional values https://www.terraform.io/language/expressions/type-constraints#optional-object-type-attributes but on the other hand It would force users to use terraform >= 1.3 ... so again .. breaking.

So in the end I am not sure if it's worth to have description here but I let you deside :D