### PR TITLE
feat!: Add BQ authorized routine (function) in authorization sub-module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/basic_bq/main.tf
+++ b/examples/basic_bq/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_bq/outputs.tf
+++ b/examples/basic_bq/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_bq/variables.tf
+++ b/examples/basic_bq/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_bq/versions.tf
+++ b/examples/basic_bq/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_view/main.tf
+++ b/examples/basic_view/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_view/outputs.tf
+++ b/examples/basic_view/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_view/variables.tf
+++ b/examples/basic_view/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/basic_view/versions.tf
+++ b/examples/basic_view/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/multiple_tables/outputs.tf
+++ b/examples/multiple_tables/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/multiple_tables/provider.tf
+++ b/examples/multiple_tables/provider.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/multiple_tables/variables.tf
+++ b/examples/multiple_tables/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/multiple_tables/versions.tf
+++ b/examples/multiple_tables/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/scheduled_queries/main.tf
+++ b/examples/scheduled_queries/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/scheduled_queries/outputs.tf
+++ b/examples/scheduled_queries/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/scheduled_queries/versions.tf
+++ b/examples/scheduled_queries/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/authorization/README.md
+++ b/modules/authorization/README.md
@@ -1,8 +1,7 @@
-# BigQuery Authorized Views
+# BigQuery Authorized Datasets, Views and Routines
 
-This submodule is used to add [authorized views](https://cloud.google.com/bigquery/docs/share-access-views#authorize_the_view_to_access_the_source_dataset).
-The views that are created at another dataset are given readonly access so that even if the user does not have read access to the real dataset,
-they can read data over the view.
+This submodule is used to add [authorized datasets](https://cloud.google.com/bigquery/docs/authorized-datasets), [authorized views](https://cloud.google.com/bigquery/docs/share-access-views#authorize_the_view_to_access_the_source_dataset) and [authorized routines](https://cloud.google.com/bigquery/docs/authorized-functions).
+An `authorized dataset` lets you authorize all of the views in a specified dataset to access the data in a second dataset. An `authorized view` lets you share query results with particular users and groups without giving them access to the underlying source data. `Authorized Routine (Function)` let you share query results with particular users or groups without giving those users or groups access to the underlying tables
 
 ## Background
 It is possible to define authorized views while creating a dataset. However, we have a chicken&egg problem if we create all at the same time. This module has the goal of solving that.
@@ -65,7 +64,8 @@ module "add_authorization" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | authorized\_datasets | An array of datasets to be authorized on the dataset | <pre>list(object({<br>    dataset_id = string,<br>    project_id = string,<br>  }))</pre> | `[]` | no |
-| authorized\_views | An array of views to give authorize for the dataset | <pre>list(object({<br>    dataset_id = string,<br>    project_id = string,<br>    table_id   = string # this is the view id, but we keep table_id to stay consistent as the resource<br>  }))</pre> | n/a | yes |
+| authorized\_routines | An array of authorized routine to be authorized on the dataset | <pre>list(object({<br>    project_id = string,<br>    dataset_id = string,<br>    routine_id = string<br>  }))</pre> | `[]` | no |
+| authorized\_views | An array of views to give authorize for the dataset | <pre>list(object({<br>    dataset_id = string,<br>    project_id = string,<br>    table_id   = string # this is the view id, but we keep table_id to stay consistent as the resource<br>  }))</pre> | `[]` | no |
 | dataset\_id | Unique ID for the dataset being provisioned. | `string` | n/a | yes |
 | project\_id | Project where the dataset and table are created | `string` | n/a | yes |
 | roles | An array of objects that define dataset access for one or more entities. | `any` | `[]` | no |

--- a/modules/authorization/main.tf
+++ b/modules/authorization/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ locals {
   roles    = zipmap(local.role_keys, var.roles)
   views    = { for view in var.authorized_views : "${view["project_id"]}_${view["dataset_id"]}_${view["table_id"]}" => view }
   datasets = { for dataset in var.authorized_datasets : "${dataset["project_id"]}_${dataset["dataset_id"]}" => dataset }
+  routines = { for routine in var.authorized_routines : "${routine["project_id"]}_${routine["dataset_id"]}_${routine["routine_id"]}" => routine }
 
   iam_to_primitive = {
     "roles/bigquery.dataOwner" : "OWNER"
@@ -71,5 +72,16 @@ resource "google_bigquery_dataset_access" "authorized_dataset" {
       dataset_id = each.value.dataset_id
     }
     target_types = ["VIEWS"]
+  }
+}
+
+resource "google_bigquery_dataset_access" "authorized_routine" {
+  for_each   = local.routines
+  dataset_id = var.dataset_id
+  project    = var.project_id
+  routine {
+    project_id = each.value.project_id
+    dataset_id = each.value.dataset_id
+    routine_id = each.value.routine_id
   }
 }

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/authorization/outputs.tf
+++ b/modules/authorization/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/authorization/variables.tf
+++ b/modules/authorization/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ variable "authorized_views" {
     project_id = string,
     table_id   = string # this is the view id, but we keep table_id to stay consistent as the resource
   }))
+  default = []
 }
 
 variable "authorized_datasets" {
@@ -50,6 +51,16 @@ variable "authorized_datasets" {
   type = list(object({
     dataset_id = string,
     project_id = string,
+  }))
+  default = []
+}
+
+variable "authorized_routines" {
+  description = "An array of authorized routine to be authorized on the dataset"
+  type = list(object({
+    project_id = string,
+    dataset_id = string,
+    routine_id = string
   }))
   default = []
 }

--- a/modules/authorization/versions.tf
+++ b/modules/authorization/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 4.44, < 5.0"
     }
   }
 

--- a/modules/scheduled_queries/main.tf
+++ b/modules/scheduled_queries/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/scheduled_queries/outputs.tf
+++ b/modules/scheduled_queries/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/scheduled_queries/variables.tf
+++ b/modules/scheduled_queries/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/scheduled_queries/versions.tf
+++ b/modules/scheduled_queries/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/udf/main.tf
+++ b/modules/udf/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/udf/outputs.tf
+++ b/modules/udf/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/udf/scripts/persistent_udfs.sh
+++ b/modules/udf/scripts/persistent_udfs.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/udf/variables.tf
+++ b/modules/udf/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/udf/versions.tf
+++ b/modules/udf/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/full/outputs.tf
+++ b/test/fixtures/full/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/full/variables.tf
+++ b/test/fixtures/full/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/full/controls/big_query.rb
+++ b/test/integration/full/controls/big_query.rb
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/full/inspec.yml
+++ b/test/integration/full/inspec.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/setup/variables.tf
+++ b/test/setup/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix #181 
Bumped min provider version to 4.44 in `authorization` sub-module for [authorized routine](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#4440-november-21-2022).
Added BQ authorized routine to authorization sub-module. 
Added example for authorized view and and authorized routine.
