### PR TITLE
fix: disable deletion protection for external tables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ resource "google_bigquery_table" "external_table" {
   labels              = each.value["labels"]
   expiration_time     = each.value["expiration_time"]
   project             = var.project_id
-  deletion_protection = var.deletion_protection
+  deletion_protection = false
 
   external_data_configuration {
     autodetect            = each.value["autodetect"]


### PR DESCRIPTION
External tables are in some way, similar to views, data from them is [read-only](https://cloud.google.com/bigquery/docs/external-tables#limitations), hence there is no need to protect them since the data won't be deleted.