### PR TITLE
chore: Mark some table attributes as optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -103,22 +103,22 @@ variable "tables" {
     table_name  = optional(string),
     schema      = string,
     clustering  = list(string),
-    time_partitioning = object({
+    time_partitioning = optional(object({
       expiration_ms            = string,
       field                    = string,
       type                     = string,
       require_partition_filter = bool,
-    }),
-    range_partitioning = object({
+    })),
+    range_partitioning = optional(object({
       field = string,
       range = object({
         start    = string,
         end      = string,
         interval = string,
       }),
-    }),
-    expiration_time = string,
-    labels          = map(string),
+    })),
+    expiration_time = optional(string),
+    labels          = optional(map(string)),
   }))
 }
 


### PR DESCRIPTION
## Summary

This change made the following attributes optional.

* time_partitioning
* range_partitioning
* expiration_time
* labels

It's completely valid (and have legitimate reasons to) not to provide the attributes in the [google_bigquery_table](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table) resource.

Currently, these attributes are treated as `required` and cause the plan, apply to fail if not provided.