### PR TITLE
fix: set schema as optional for external tables

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ spec:
     version: 7.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     subBlueprints:
@@ -101,7 +101,7 @@ spec:
               compression           = string,
               ignore_unknown_values = bool,
               max_bad_records       = number,
-              schema                = string,
+              schema                = optional(string),
               source_format         = string,
               source_uris           = list(string),
               csv_options = object({

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 7.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 7.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -28,7 +28,7 @@ spec:
     version: 7.0.0
     actuationTool:
       flavor: Terraform
-      version: ">= 0.13"
+      version: ">= 1.3"
     description: {}
   content:
     examples:

--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable "external_tables" {
     compression           = string,
     ignore_unknown_values = bool,
     max_bad_records       = number,
-    schema                = string,
+    schema                = optional(string),
     source_format         = string,
     source_uris           = list(string),
     csv_options = object({


### PR DESCRIPTION
When using auto-detect mechanism, external table schema isn't needed. Hence, optional.

Ref: https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#externaldataconfiguration
> Optional. The schema for the data. Schema is required for CSV and JSON formats if autodetect is not on. Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, Avro, ORC and Parquet formats.


https://github.com/hashicorp/terraform-provider-google/blob/3d7632af6b73a3edae04c7204a38525b7a5f6262/google/services/bigquery/resource_bigquery_table.go#L498-L502