### PR TITLE
Set terraform version constraint to ~> 1.3

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.3"
   required_providers {
 
     google = {


### PR DESCRIPTION
The constraint allows any version in the 1.x series higher than 1.3. The module requires 1.3 because it uses optional object type attributes.

fixes #279