### PR TITLE
fix: support to max_staleness introduced in #278

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.42, < 6"
+      version = ">= 4.78, < 6"
     }
   }
 


### PR DESCRIPTION
Bump the minimum provider version to 4.78 since #278 was merged some time ago introducing support to `max_staleness`.  This module is currently broken in master for anyone using a version < 4.78