### PR TITLE
feat: Set Terraform required_version to >= 1.5

### DIFF
--- a/modules/data_warehouse/versions.tf
+++ b/modules/data_warehouse/versions.tf
@@ -15,6 +15,7 @@
  */
 
 terraform {
+  required_version = ">= 1.5"
   required_providers {
     google = {
       source  = "hashicorp/google"
@@ -45,7 +46,6 @@ terraform {
       version = "3.6.2"
     }
   }
-  required_version = ">= 0.13"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-bigquery:data_warehouse/v8.1.0"


### PR DESCRIPTION
* Please see [this GitHub issue](https://github.com/GoogleCloudPlatform/terraform-google-three-tier-web-app/issues/144) about requiring a minimum Terraform version between 1.3-1.5 for the "Three-tier web app" JSS (Jump Start Solution).
* We'll need to do the above for all JSSs — including _this_ JSS.
