### PR TITLE
fix(TPG>=6.11)!: add deletion protection variable to google_workflows_workflow

### DIFF
--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/authorization/metadata.display.yaml
+++ b/modules/authorization/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -106,4 +106,4 @@ spec:
       - iam.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.39, < 7"
+        version: ">= 4.44, < 7"

--- a/modules/data_warehouse/metadata.display.yaml
+++ b/modules/data_warehouse/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,5 +140,17 @@ spec:
       - serviceusage.googleapis.com
       - iam.googleapis.com
     providerVersions:
+      - source: hashicorp/archive
+        version: 2.4.2
       - source: hashicorp/google
-        version: ">= 5.39, < 7"
+        version: ">= 4.52, < 7"
+      - source: hashicorp/google-beta
+        version: ">= 4.52, < 7"
+      - source: hashicorp/http
+        version: ">= 2"
+      - source: hashicorp/local
+        version: ">=2.4"
+      - source: hashicorp/random
+        version: 3.6.2
+      - source: hashicorp/time
+        version: ">= 0.9.1"

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -143,9 +143,9 @@ spec:
       - source: hashicorp/archive
         version: 2.4.2
       - source: hashicorp/google
-        version: ">= 4.52, < 7"
+        version: ">= 6.11, < 7"
       - source: hashicorp/google-beta
-        version: ">= 4.52, < 7"
+        version: ">= 6.11, < 7"
       - source: hashicorp/http
         version: ">= 2"
       - source: hashicorp/local

--- a/modules/data_warehouse/versions.tf
+++ b/modules/data_warehouse/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.52, < 7"
+      version = ">= 6.11, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.52, < 7"
+      version = ">= 6.11, < 7"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/modules/data_warehouse/workflows.tf
+++ b/modules/data_warehouse/workflows.tf
@@ -66,6 +66,8 @@ resource "google_workflows_workflow" "workflow" {
     function_name = google_cloudfunctions2_function.notebook_deploy_function.name
   })
 
+  deletion_protection = var.deletion_protection
+
   labels = var.labels
 
   depends_on = [

--- a/modules/scheduled_queries/metadata.display.yaml
+++ b/modules/scheduled_queries/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,4 +72,4 @@ spec:
       - iam.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.39, < 7"
+        version: ">= 4.0, < 7"

--- a/modules/udf/metadata.display.yaml
+++ b/modules/udf/metadata.display.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,4 +76,4 @@ spec:
       - iam.googleapis.com
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.39, < 7"
+        version: ">= 3.53, < 7"


### PR DESCRIPTION
Fixes #368 - `deletion_protection` being introduced to `google_workflows_workflow`