### PR TITLE
chore: generate root module output type metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,17 +1,3 @@
-# Copyright 2025 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: blueprints.cloud.google.com/v1alpha1
 kind: BlueprintMetadata
 metadata:
@@ -230,28 +216,143 @@ spec:
     outputs:
       - name: bigquery_dataset
         description: Bigquery dataset resource.
+        type:
+          - object
+          - access:
+              - set
+              - - object
+                - condition:
+                    - list
+                    - - object
+                      - description: string
+                        expression: string
+                        location: string
+                        title: string
+                  dataset:
+                    - list
+                    - - object
+                      - dataset:
+                          - list
+                          - - object
+                            - dataset_id: string
+                              project_id: string
+                        target_types:
+                          - list
+                          - string
+                  domain: string
+                  group_by_email: string
+                  iam_member: string
+                  role: string
+                  routine:
+                    - list
+                    - - object
+                      - dataset_id: string
+                        project_id: string
+                        routine_id: string
+                  special_group: string
+                  user_by_email: string
+                  view:
+                    - list
+                    - - object
+                      - dataset_id: string
+                        project_id: string
+                        table_id: string
+            creation_time: number
+            dataset_id: string
+            default_collation: string
+            default_encryption_configuration:
+              - list
+              - - object
+                - kms_key_name: string
+            default_partition_expiration_ms: number
+            default_table_expiration_ms: number
+            delete_contents_on_destroy: bool
+            description: string
+            effective_labels:
+              - map
+              - string
+            etag: string
+            external_dataset_reference:
+              - list
+              - - object
+                - connection: string
+                  external_source: string
+            friendly_name: string
+            id: string
+            is_case_insensitive: bool
+            labels:
+              - map
+              - string
+            last_modified_time: number
+            location: string
+            max_time_travel_hours: string
+            project: string
+            resource_tags:
+              - map
+              - string
+            self_link: string
+            storage_billing_model: string
+            terraform_labels:
+              - map
+              - string
+            timeouts:
+              - object
+              - create: string
+                delete: string
+                update: string
       - name: bigquery_external_tables
         description: Map of BigQuery external table resources being provisioned.
+        type:
+          - object
+          - {}
       - name: bigquery_tables
         description: Map of bigquery table resources being provisioned.
+        type:
+          - object
+          - {}
       - name: bigquery_views
         description: Map of bigquery view resources being provisioned.
+        type:
+          - object
+          - {}
       - name: external_table_ids
         description: Unique IDs for any external tables being provisioned
+        type:
+          - tuple
+          - []
       - name: external_table_names
         description: Friendly names for any external tables being provisioned
+        type:
+          - tuple
+          - []
       - name: project
         description: Project where the dataset and tables are created
+        type: string
       - name: routine_ids
         description: Unique IDs for any routine being provisioned
+        type:
+          - tuple
+          - []
       - name: table_ids
         description: Unique id for the table being provisioned
+        type:
+          - tuple
+          - []
       - name: table_names
         description: Friendly name for the table being provisioned
+        type:
+          - tuple
+          - []
       - name: view_ids
         description: Unique id for the view being provisioned
+        type:
+          - tuple
+          - []
       - name: view_names
         description: friendlyname for the view being provisioned
+        type:
+          - tuple
+          - []
   requirements:
     roles:
       - level: Project

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -38,16 +38,23 @@ spec:
       description: cost of this solution is $0.65
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d
     cloudProducts:
-      - productId: search_BIGQUERY_SECTION
-      - productId: WORKFLOWS_SECTION
-      - productId: STORAGE_SECTION
-      - productId: ai-platform
-      - productId: LOOKER_STUDIO_SECTION
-        pageUrl: lookerstudio.google.com
-        isExternal: true
-      - productId: CLOUD_DMS_SECTION
-      - productId: FUNCTIONS_SECTION
-      - productId: DATAFORM_SECTION
+    - productId: search_BIGQUERY_SECTION
+      pageUrl: ""
+    - productId: WORKFLOWS_SECTION
+      pageUrl: ""
+    - productId: STORAGE_SECTION
+      pageUrl: ""
+    - productId: ai-platform
+      pageUrl: ""
+    - productId: LOOKER_STUDIO_SECTION
+      pageUrl: lookerstudio.google.com
+      isExternal: true
+    - productId: CLOUD_DMS_SECTION
+      pageUrl: ""
+    - productId: FUNCTIONS_SECTION
+      pageUrl: ""
+    - productId: DATAFORM_SECTION
+      pageUrl: ""
   content:
     architecture:
       diagramUrl: www.gstatic.com/pantheon/images/solutions/data-warehouse-architecture_v6.svg

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -32,8 +32,8 @@ spec:
     description: {}
     icon: assets/data_warehouse_icon_v1.png
     deploymentDuration:
-      configurationSecs: "120"
-      deploymentSecs: "420"
+      configurationSecs: 120
+      deploymentSecs: 420
     costEstimate:
       description: cost of this solution is $0.65
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d


### PR DESCRIPTION
Generate root module output type metadata via:

```
cft blueprint metadata  --generate-output-type
```