### PR TITLE
fix: Use list(string) instead of tuple for some of the output variables

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -342,41 +342,41 @@ spec:
       - name: external_table_ids
         description: Unique IDs for any external tables being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
       - name: external_table_names
         description: Friendly names for any external tables being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
       - name: project
         description: Project where the dataset and tables are created
         type: string
       - name: routine_ids
         description: Unique IDs for any routine being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
       - name: table_ids
         description: Unique id for the table being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
       - name: table_names
         description: Friendly name for the table being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
       - name: view_ids
         description: Unique id for the view being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
       - name: view_names
         description: friendlyname for the view being provisioned
         type:
-          - tuple
-          - []
+          - list
+          - string
   requirements:
     roles:
       - level: Project


### PR DESCRIPTION
Change output variable types for some of the variables from tuple to list. Tuples are used when the number of elements and their types are known. Since this module supports creating any number of tables, views etc. they should be list instead of tuple.