### PR TITLE
chore: update display metadata to fix regex for bigquery dataset id

### DIFF
--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -33,7 +33,7 @@ spec:
         dataset_id:
           name: dataset_id
           title: Dataset Id
-          regexValidation: ^[a-zA-Z0-9_]{1,1024}$
+          regexValidation: ^[a-zA-Z0-9_]{1,1000}$
           validation: Must contain only letters, numbers, or underscores. Must be 1024 characters or fewer.
         dataset_labels:
           name: dataset_labels

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -33,7 +33,7 @@ spec:
         dataset_id:
           name: dataset_id
           title: Dataset Id
-          regexValidation: ^[a-zA-Z0-9_]{1,1024}$$
+          regexValidation: ^[a-zA-Z0-9_]{1,1024}$
           validation: Must contain only letters, numbers, or underscores. Must be 1024 characters or fewer.
         dataset_labels:
           name: dataset_labels

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -90,7 +90,7 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value:
-                - schema: "[{\"description\": \"Default String Value\",\"mode\": \"NULLABLE\",\"name\": \"defaultStringValue\",\"type\": \"STRING\"},{\"description\": \"Default Number Value\",\"mode\": \"NULLABLE\",\"name\": \"defaultNumberValue\",\"type\": \"INTEGER\"},{\"description\": \"Data\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
+                - schema: "[{\"description\": \"An example string field. Illustrates the storage of textual data compliant with STRING type\",\"mode\": \"NULLABLE\",\"name\": \"exampleID\",\"type\": \"STRING\"},{\"description\": \"An integer value. Demonstrates the representation of whole number data compliant with INTEGER type\",\"mode\": \"NULLABLE\",\"name\": \"numberField\",\"type\": \"INTEGER\"},{\"description\": \"This field stores data crucial for Google Cloud Pub/Sub connectivity\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
                   table_id: table-1
         views:
           name: views

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -90,7 +90,7 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value:
-                - schema: "[{\"description\": \"An example string field. Illustrates the storage of textual data compliant with STRING type\",\"mode\": \"NULLABLE\",\"name\": \"exampleID\",\"type\": \"STRING\"},{\"description\": \"An integer value. Demonstrates the representation of whole number data compliant with INTEGER type\",\"mode\": \"NULLABLE\",\"name\": \"numberField\",\"type\": \"INTEGER\"},{\"description\": \"This field stores data crucial for Google Cloud Pub/Sub connectivity\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
+                - schema: "[{\"description\": \"A string type unique identifier\",\"mode\": \"NULLABLE\",\"name\": \"simpleId\",\"type\": \"STRING\"},{\"description\": \"A field to hold integer values\",\"mode\": \"NULLABLE\",\"name\": \"integerField\",\"type\": \"INTEGER\"},{\"description\": \"Data\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
                   table_id: table-1
         views:
           name: views

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -90,7 +90,7 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value:
-                - schema: "[{\"description\": \"Full visitor ID\",\"mode\": \"NULLABLE\",\"name\": \"fullVisitorId\",\"type\": \"STRING\"},{\"description\": \"Visit number\",\"mode\": \"NULLABLE\",\"name\": \"visitNumber\",\"type\": \"INTEGER\"}]"
+                - schema: "[{\"description\": \"Full visitor ID\",\"mode\": \"NULLABLE\",\"name\": \"fullVisitorId\",\"type\": \"STRING\"},{\"description\": \"Visit number\",\"mode\": \"NULLABLE\",\"name\": \"visitNumber\",\"type\": \"INTEGER\"},{\"description\": \"Data\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
                   table_id: table-1
         views:
           name: views

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -33,7 +33,7 @@ spec:
         dataset_id:
           name: dataset_id
           title: Dataset Id
-          regexValidation: ^[a-zA-Z0-9_]{1,1000}$
+          regexValidation: ^[a-zA-Z0-9_]{1,1000}[a-zA-Z0-9_]{0,24}$
           validation: Must contain only letters, numbers, or underscores. Must be 1024 characters or fewer.
         dataset_labels:
           name: dataset_labels
@@ -90,7 +90,7 @@ spec:
           altDefaults:
             - type: ALTERNATE_TYPE_DC
               value:
-                - schema: "[{\"description\": \"Full visitor ID\",\"mode\": \"NULLABLE\",\"name\": \"fullVisitorId\",\"type\": \"STRING\"},{\"description\": \"Visit number\",\"mode\": \"NULLABLE\",\"name\": \"visitNumber\",\"type\": \"INTEGER\"},{\"description\": \"Data\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
+                - schema: "[{\"description\": \"Default String Value\",\"mode\": \"NULLABLE\",\"name\": \"defaultStringValue\",\"type\": \"STRING\"},{\"description\": \"Default Number Value\",\"mode\": \"NULLABLE\",\"name\": \"defaultNumberValue\",\"type\": \"INTEGER\"},{\"description\": \"Data\",\"mode\": \"NULLABLE\",\"name\": \"data\",\"type\": \"STRING\"}]"
                   table_id: table-1
         views:
           name: views


### PR DESCRIPTION
fix regex for bigquery dataset id as go regexp library has limit of 1000 for repeat count