### PR TITLE
fix: proper provisioning order for views and materialized views

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "google_bigquery_table" "view" {
   for_each            = local.views
   dataset_id          = google_bigquery_dataset.main.dataset_id
   friendly_name       = each.key
-  table_id            = each.key
+  table_id            = contains(keys(local.tables), each.key) ? google_bigquery_table.main[each.key].table_id : each.key
   description         = each.value["description"]
   labels              = each.value["labels"]
   project             = var.project_id
@@ -135,7 +135,7 @@ resource "google_bigquery_table" "materialized_view" {
   for_each            = local.materialized_views
   dataset_id          = google_bigquery_dataset.main.dataset_id
   friendly_name       = each.key
-  table_id            = each.key
+  table_id            = contains(keys(local.tables), each.key) ? google_bigquery_table.main[each.key].table_id : each.key
   description         = each.value["description"]
   labels              = each.value["labels"]
   clustering          = each.value["clustering"]


### PR DESCRIPTION
This PR updates the table_id assignment logic in the `google_bigquery_table.view` and `google_bigquery_table.materialized_view` to fix provisioning order issues when views depend on existing base tables.

This helps avoid errors like "Table not found" during apply, which were caused by views being created before their underlying tables:
```
Error: googleapi: Error 404: Not found: Table <project>:<dataset>.<table> was not found in location <region>, notFound

  with module.<module-name>[0].google_bigquery_table.view["<table>_view"],
  on .terraform/modules/<module-name>/terraform-google-modules/bigquery/google/main.tf line 103, in resource "google_bigquery_table" "view":
 103: resource "google_bigquery_table" "view" {
```

Thanks to @[EliSzBr](https://github.com/EliSzBr) for the help!