### PR TITLE
feat: per module requirements configs for bigquery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 ENABLE_BPMETADATA := 1

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.23
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 ENABLE_BPMETADATA := 1
@@ -82,7 +82,7 @@ docker_generate_docs:
 		-e ENABLE_BPMETADATA \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs -d'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs -d --per-module-requirements'
 
 # Alias for backwards compatibility
 .PHONY: generate_docs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -386,28 +386,13 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
           - roles/bigquery.admin
-          - roles/aiplatform.admin
-          - roles/dataform.admin
           - roles/iam.serviceAccountAdmin
-          - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
-          - roles/workflows.admin
-          - roles/cloudfunctions.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountTokenCreator
-          - roles/iam.serviceAccountUser
     services:
       - bigquery.googleapis.com
-      - bigqueryconnection.googleapis.com
-      - bigquerystorage.googleapis.com
-      - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com
-      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 5.39, < 7"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -386,28 +386,28 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/bigquery.admin
-          - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
+          - roles/logging.configWriter
+          - roles/run.invoker
           - roles/dataform.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
-          - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
           - roles/serviceusage.serviceUsageAdmin
           - roles/storage.admin
           - roles/workflows.admin
+          - roles/bigquery.admin
+          - roles/aiplatform.admin
+          - roles/cloudfunctions.admin
+          - roles/datalineage.viewer
+          - roles/iam.serviceAccountAdmin
     services:
+      - bigquery.googleapis.com
+      - bigqueryconnection.googleapis.com
+      - bigquerystorage.googleapis.com
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
-      - bigquery.googleapis.com
-      - bigquerystorage.googleapis.com
-      - bigqueryconnection.googleapis.com
-      - serviceusage.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 5.39, < 7"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -387,10 +387,12 @@ spec:
       - level: Project
         roles:
           - roles/bigquery.admin
-          - roles/iam.serviceAccountAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/storage.admin
+          - roles/cloudkms.cryptoKeyEncrypterDecrypter
     services:
       - bigquery.googleapis.com
+      - bigquerystorage.googleapis.com
+      - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -386,20 +386,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.configWriter
-          - roles/run.invoker
-          - roles/dataform.admin
-          - roles/iam.serviceAccountTokenCreator
-          - roles/iam.serviceAccountUser
-          - roles/resourcemanager.projectIamAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/storage.admin
-          - roles/workflows.admin
           - roles/bigquery.admin
           - roles/aiplatform.admin
+          - roles/dataform.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/logging.configWriter
+          - roles/resourcemanager.projectIamAdmin
+          - roles/run.invoker
+          - roles/workflows.admin
           - roles/cloudfunctions.admin
           - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
+          - roles/iam.serviceAccountTokenCreator
+          - roles/iam.serviceAccountUser
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -93,20 +93,20 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/run.invoker
+          - roles/storage.admin
           - roles/workflows.admin
+          - roles/bigquery.admin
+          - roles/aiplatform.admin
           - roles/cloudfunctions.admin
           - roles/dataform.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
           - roles/logging.configWriter
-          - roles/resourcemanager.projectIamAdmin
-          - roles/bigquery.admin
-          - roles/aiplatform.admin
-          - roles/run.invoker
           - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
+          - roles/datalineage.viewer
+          - roles/iam.serviceAccountAdmin
+          - roles/resourcemanager.projectIamAdmin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -93,20 +93,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/run.invoker
-          - roles/bigquery.admin
-          - roles/dataform.admin
-          - roles/logging.configWriter
+          - roles/aiplatform.admin
+          - roles/cloudfunctions.admin
+          - roles/iam.serviceAccountAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/storage.admin
           - roles/workflows.admin
-          - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
+          - roles/bigquery.admin
+          - roles/dataform.admin
           - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
+          - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
+          - roles/run.invoker
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -93,20 +93,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
-          - roles/iam.serviceAccountAdmin
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
           - roles/workflows.admin
-          - roles/bigquery.admin
+          - roles/cloudfunctions.admin
           - roles/dataform.admin
           - roles/datalineage.viewer
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
           - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
+          - roles/bigquery.admin
+          - roles/aiplatform.admin
           - roles/run.invoker
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/authorization/metadata.yaml
+++ b/modules/authorization/metadata.yaml
@@ -93,28 +93,28 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/run.invoker
           - roles/bigquery.admin
+          - roles/dataform.admin
+          - roles/logging.configWriter
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
+          - roles/workflows.admin
           - roles/aiplatform.admin
           - roles/cloudfunctions.admin
-          - roles/dataform.admin
           - roles/datalineage.viewer
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
-          - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
     services:
+      - bigquery.googleapis.com
+      - bigqueryconnection.googleapis.com
+      - bigquerystorage.googleapis.com
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
-      - bigquery.googleapis.com
-      - bigquerystorage.googleapis.com
-      - bigqueryconnection.googleapis.com
-      - serviceusage.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.44, < 7"

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -32,29 +32,22 @@ spec:
     description: {}
     icon: assets/data_warehouse_icon_v1.png
     deploymentDuration:
-      configurationSecs: 120
-      deploymentSecs: 420
+      configurationSecs: "120"
+      deploymentSecs: "420"
     costEstimate:
       description: cost of this solution is $0.65
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d
     cloudProducts:
-    - productId: search_BIGQUERY_SECTION
-      pageUrl: ""
-    - productId: WORKFLOWS_SECTION
-      pageUrl: ""
-    - productId: STORAGE_SECTION
-      pageUrl: ""
-    - productId: ai-platform
-      pageUrl: ""
-    - productId: LOOKER_STUDIO_SECTION
-      pageUrl: lookerstudio.google.com
-      isExternal: true
-    - productId: CLOUD_DMS_SECTION
-      pageUrl: ""
-    - productId: FUNCTIONS_SECTION
-      pageUrl: ""
-    - productId: DATAFORM_SECTION
-      pageUrl: ""
+      - productId: search_BIGQUERY_SECTION
+      - productId: WORKFLOWS_SECTION
+      - productId: STORAGE_SECTION
+      - productId: ai-platform
+      - productId: LOOKER_STUDIO_SECTION
+        pageUrl: lookerstudio.google.com
+        isExternal: true
+      - productId: CLOUD_DMS_SECTION
+      - productId: FUNCTIONS_SECTION
+      - productId: DATAFORM_SECTION
   content:
     architecture:
       diagramUrl: www.gstatic.com/pantheon/images/solutions/data-warehouse-architecture_v6.svg
@@ -135,20 +128,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
+          - roles/dataform.admin
           - roles/datalineage.viewer
           - roles/iam.serviceAccountTokenCreator
           - roles/logging.configWriter
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
+          - roles/run.invoker
           - roles/workflows.admin
-          - roles/bigquery.admin
           - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
-          - roles/dataform.admin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
+          - roles/resourcemanager.projectIamAdmin
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
+          - roles/bigquery.admin
+          - roles/cloudfunctions.admin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -135,20 +135,20 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/storage.admin
+          - roles/aiplatform.admin
+          - roles/cloudfunctions.admin
           - roles/dataform.admin
+          - roles/iam.serviceAccountUser
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/workflows.admin
+          - roles/bigquery.admin
           - roles/datalineage.viewer
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/logging.configWriter
-          - roles/run.invoker
-          - roles/workflows.admin
-          - roles/aiplatform.admin
-          - roles/iam.serviceAccountAdmin
-          - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
-          - roles/bigquery.admin
-          - roles/cloudfunctions.admin
+          - roles/run.invoker
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -39,15 +39,22 @@ spec:
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d
     cloudProducts:
       - productId: search_BIGQUERY_SECTION
+        pageUrl: ""
       - productId: WORKFLOWS_SECTION
+        pageUrl: ""
       - productId: STORAGE_SECTION
+        pageUrl: ""
       - productId: ai-platform
+        pageUrl: ""
       - productId: LOOKER_STUDIO_SECTION
         pageUrl: lookerstudio.google.com
         isExternal: true
       - productId: CLOUD_DMS_SECTION
+        pageUrl: ""
       - productId: FUNCTIONS_SECTION
+        pageUrl: ""
       - productId: DATAFORM_SECTION
+        pageUrl: ""
   content:
     architecture:
       diagramUrl: www.gstatic.com/pantheon/images/solutions/data-warehouse-architecture_v6.svg

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -32,29 +32,22 @@ spec:
     description: {}
     icon: assets/data_warehouse_icon_v1.png
     deploymentDuration:
-      configurationSecs: 120
-      deploymentSecs: 420
+      configurationSecs: "120"
+      deploymentSecs: "420"
     costEstimate:
       description: cost of this solution is $0.65
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d
     cloudProducts:
-    - productId: search_BIGQUERY_SECTION
-      pageUrl: ""
-    - productId: WORKFLOWS_SECTION
-      pageUrl: ""
-    - productId: STORAGE_SECTION
-      pageUrl: ""
-    - productId: ai-platform
-      pageUrl: ""
-    - productId: LOOKER_STUDIO_SECTION
-      pageUrl: lookerstudio.google.com
-      isExternal: true
-    - productId: CLOUD_DMS_SECTION
-      pageUrl: ""
-    - productId: FUNCTIONS_SECTION
-      pageUrl: ""
-    - productId: DATAFORM_SECTION
-      pageUrl: ""
+      - productId: search_BIGQUERY_SECTION
+      - productId: WORKFLOWS_SECTION
+      - productId: STORAGE_SECTION
+      - productId: ai-platform
+      - productId: LOOKER_STUDIO_SECTION
+        pageUrl: lookerstudio.google.com
+        isExternal: true
+      - productId: CLOUD_DMS_SECTION
+      - productId: FUNCTIONS_SECTION
+      - productId: DATAFORM_SECTION
   content:
     architecture:
       diagramUrl: www.gstatic.com/pantheon/images/solutions/data-warehouse-architecture_v6.svg
@@ -135,31 +128,31 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/workflows.admin
           - roles/bigquery.admin
           - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
           - roles/dataform.admin
           - roles/datalineage.viewer
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
           - roles/logging.configWriter
+          - roles/cloudfunctions.admin
           - roles/resourcemanager.projectIamAdmin
           - roles/run.invoker
           - roles/serviceusage.serviceUsageAdmin
           - roles/storage.admin
-          - roles/workflows.admin
     services:
+      - bigquery.googleapis.com
+      - bigqueryconnection.googleapis.com
+      - bigquerystorage.googleapis.com
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
-      - bigquery.googleapis.com
-      - bigquerystorage.googleapis.com
-      - bigqueryconnection.googleapis.com
-      - serviceusage.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/archive
-        version: 10.1.1
+        version: ">= 2.4.2"
       - source: hashicorp/google
         version: ">= 6.11, < 7"
       - source: hashicorp/google-beta
@@ -167,8 +160,8 @@ spec:
       - source: hashicorp/http
         version: ">= 2"
       - source: hashicorp/local
-        version: ">=2.4"
+        version: ">= 2.4"
       - source: hashicorp/random
-        version: 10.1.1
+        version: ">= 3.6.2"
       - source: hashicorp/time
         version: ">= 0.9.1"

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -32,8 +32,8 @@ spec:
     description: {}
     icon: assets/data_warehouse_icon_v1.png
     deploymentDuration:
-      configurationSecs: "120"
-      deploymentSecs: "420"
+      configurationSecs: 120
+      deploymentSecs: 420
     costEstimate:
       description: cost of this solution is $0.65
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d

--- a/modules/data_warehouse/metadata.yaml
+++ b/modules/data_warehouse/metadata.yaml
@@ -32,22 +32,29 @@ spec:
     description: {}
     icon: assets/data_warehouse_icon_v1.png
     deploymentDuration:
-      configurationSecs: "120"
-      deploymentSecs: "420"
+      configurationSecs: 120
+      deploymentSecs: 420
     costEstimate:
       description: cost of this solution is $0.65
       url: https://cloud.google.com/products/calculator/#id=857776c6-49e8-4c6a-adc5-42a15b8fb67d
     cloudProducts:
-      - productId: search_BIGQUERY_SECTION
-      - productId: WORKFLOWS_SECTION
-      - productId: STORAGE_SECTION
-      - productId: ai-platform
-      - productId: LOOKER_STUDIO_SECTION
-        pageUrl: lookerstudio.google.com
-        isExternal: true
-      - productId: CLOUD_DMS_SECTION
-      - productId: FUNCTIONS_SECTION
-      - productId: DATAFORM_SECTION
+    - productId: search_BIGQUERY_SECTION
+      pageUrl: ""
+    - productId: WORKFLOWS_SECTION
+      pageUrl: ""
+    - productId: STORAGE_SECTION
+      pageUrl: ""
+    - productId: ai-platform
+      pageUrl: ""
+    - productId: LOOKER_STUDIO_SECTION
+      pageUrl: lookerstudio.google.com
+      isExternal: true
+    - productId: CLOUD_DMS_SECTION
+      pageUrl: ""
+    - productId: FUNCTIONS_SECTION
+      pageUrl: ""
+    - productId: DATAFORM_SECTION
+      pageUrl: ""
   content:
     architecture:
       diagramUrl: www.gstatic.com/pantheon/images/solutions/data-warehouse-architecture_v6.svg
@@ -128,20 +135,20 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/resourcemanager.projectIamAdmin
+          - roles/run.invoker
+          - roles/datalineage.viewer
+          - roles/iam.serviceAccountTokenCreator
+          - roles/logging.configWriter
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
           - roles/workflows.admin
           - roles/bigquery.admin
           - roles/aiplatform.admin
-          - roles/dataform.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
-          - roles/iam.serviceAccountTokenCreator
-          - roles/iam.serviceAccountUser
-          - roles/logging.configWriter
           - roles/cloudfunctions.admin
-          - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
+          - roles/dataform.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/iam.serviceAccountUser
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -59,20 +59,20 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/cloudfunctions.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/serviceusage.serviceUsageAdmin
           - roles/storage.admin
           - roles/workflows.admin
-          - roles/bigquery.admin
           - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
+          - roles/dataform.admin
           - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
-          - roles/run.invoker
-          - roles/dataform.admin
           - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
-          - roles/serviceusage.serviceUsageAdmin
+          - roles/run.invoker
+          - roles/bigquery.admin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -59,28 +59,28 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/iam.serviceAccountAdmin
+          - roles/iam.serviceAccountUser
+          - roles/logging.configWriter
+          - roles/resourcemanager.projectIamAdmin
+          - roles/storage.admin
+          - roles/workflows.admin
           - roles/bigquery.admin
           - roles/aiplatform.admin
           - roles/cloudfunctions.admin
           - roles/dataform.admin
           - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
-          - roles/iam.serviceAccountUser
-          - roles/logging.configWriter
-          - roles/resourcemanager.projectIamAdmin
           - roles/run.invoker
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
     services:
+      - bigquery.googleapis.com
+      - bigqueryconnection.googleapis.com
+      - bigquerystorage.googleapis.com
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
-      - bigquery.googleapis.com
-      - bigquerystorage.googleapis.com
-      - bigqueryconnection.googleapis.com
-      - serviceusage.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.0, < 7"

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -60,19 +60,19 @@ spec:
       - level: Project
         roles:
           - roles/cloudfunctions.admin
-          - roles/iam.serviceAccountAdmin
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
-          - roles/aiplatform.admin
           - roles/dataform.admin
           - roles/datalineage.viewer
+          - roles/resourcemanager.projectIamAdmin
+          - roles/run.invoker
+          - roles/workflows.admin
+          - roles/bigquery.admin
+          - roles/aiplatform.admin
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
           - roles/logging.configWriter
-          - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
-          - roles/bigquery.admin
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/scheduled_queries/metadata.yaml
+++ b/modules/scheduled_queries/metadata.yaml
@@ -59,20 +59,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/iam.serviceAccountAdmin
-          - roles/iam.serviceAccountUser
-          - roles/logging.configWriter
-          - roles/resourcemanager.projectIamAdmin
           - roles/storage.admin
           - roles/workflows.admin
           - roles/bigquery.admin
           - roles/aiplatform.admin
           - roles/cloudfunctions.admin
-          - roles/dataform.admin
           - roles/datalineage.viewer
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
+          - roles/iam.serviceAccountUser
           - roles/run.invoker
+          - roles/dataform.admin
+          - roles/logging.configWriter
+          - roles/resourcemanager.projectIamAdmin
+          - roles/serviceusage.serviceUsageAdmin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -63,20 +63,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/workflows.admin
-          - roles/aiplatform.admin
-          - roles/cloudfunctions.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
-          - roles/iam.serviceAccountTokenCreator
-          - roles/iam.serviceAccountUser
-          - roles/run.invoker
-          - roles/storage.admin
-          - roles/bigquery.admin
           - roles/dataform.admin
-          - roles/logging.configWriter
+          - roles/iam.serviceAccountAdmin
+          - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
+          - roles/run.invoker
+          - roles/workflows.admin
+          - roles/bigquery.admin
+          - roles/aiplatform.admin
+          - roles/datalineage.viewer
+          - roles/iam.serviceAccountTokenCreator
+          - roles/logging.configWriter
           - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
+          - roles/cloudfunctions.admin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -63,20 +63,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/dataform.admin
           - roles/iam.serviceAccountAdmin
+          - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
           - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
-          - roles/workflows.admin
-          - roles/bigquery.admin
-          - roles/aiplatform.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountTokenCreator
-          - roles/logging.configWriter
           - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
+          - roles/bigquery.admin
           - roles/cloudfunctions.admin
+          - roles/logging.configWriter
+          - roles/run.invoker
+          - roles/storage.admin
+          - roles/workflows.admin
+          - roles/aiplatform.admin
+          - roles/dataform.admin
+          - roles/datalineage.viewer
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -63,28 +63,28 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountAdmin
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/storage.admin
+          - roles/workflows.admin
           - roles/bigquery.admin
-          - roles/aiplatform.admin
           - roles/cloudfunctions.admin
           - roles/dataform.admin
-          - roles/datalineage.viewer
-          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
           - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
           - roles/run.invoker
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
-          - roles/workflows.admin
+          - roles/aiplatform.admin
+          - roles/datalineage.viewer
     services:
+      - bigquery.googleapis.com
+      - bigqueryconnection.googleapis.com
+      - bigquerystorage.googleapis.com
       - cloudkms.googleapis.com
       - cloudresourcemanager.googleapis.com
-      - bigquery.googleapis.com
-      - bigquerystorage.googleapis.com
-      - bigqueryconnection.googleapis.com
-      - serviceusage.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 3.53, < 7"

--- a/modules/udf/metadata.yaml
+++ b/modules/udf/metadata.yaml
@@ -63,20 +63,20 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountAdmin
-          - roles/serviceusage.serviceUsageAdmin
-          - roles/storage.admin
           - roles/workflows.admin
-          - roles/bigquery.admin
+          - roles/aiplatform.admin
           - roles/cloudfunctions.admin
-          - roles/dataform.admin
+          - roles/datalineage.viewer
+          - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountTokenCreator
           - roles/iam.serviceAccountUser
+          - roles/run.invoker
+          - roles/storage.admin
+          - roles/bigquery.admin
+          - roles/dataform.admin
           - roles/logging.configWriter
           - roles/resourcemanager.projectIamAdmin
-          - roles/run.invoker
-          - roles/aiplatform.admin
-          - roles/datalineage.viewer
+          - roles/serviceusage.serviceUsageAdmin
     services:
       - bigquery.googleapis.com
       - bigqueryconnection.googleapis.com

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -18,8 +18,8 @@ locals {
   per_module_roles = {
     root = [
       "roles/bigquery.admin",
-      "roles/iam.serviceAccountAdmin",
-      "roles/resourcemanager.projectIamAdmin",
+      "roles/storage.admin",
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter",
     ]
     authorization = [
       "roles/bigquery.admin",

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,22 +15,90 @@
  */
 
 locals {
-  int_required_roles = [
-    "roles/bigquery.admin",
-    "roles/aiplatform.admin",
-    "roles/cloudfunctions.admin",
-    "roles/dataform.admin",
-    "roles/datalineage.viewer",
-    "roles/iam.serviceAccountAdmin",
-    "roles/iam.serviceAccountTokenCreator",
-    "roles/iam.serviceAccountUser",
-    "roles/logging.configWriter",
-    "roles/resourcemanager.projectIamAdmin",
-    "roles/run.invoker",
-    "roles/serviceusage.serviceUsageAdmin",
-    "roles/storage.admin",
-    "roles/workflows.admin"
-  ]
+  per_module_roles = {
+    root = [
+      "roles/bigquery.admin",
+      "roles/aiplatform.admin",
+      "roles/cloudfunctions.admin",
+      "roles/dataform.admin",
+      "roles/datalineage.viewer",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountTokenCreator",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.configWriter",
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/run.invoker",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/storage.admin",
+      "roles/workflows.admin"
+    ]
+    authorization = [
+      "roles/bigquery.admin",
+      "roles/aiplatform.admin",
+      "roles/cloudfunctions.admin",
+      "roles/dataform.admin",
+      "roles/datalineage.viewer",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountTokenCreator",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.configWriter",
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/run.invoker",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/storage.admin",
+      "roles/workflows.admin"
+    ]
+    data_warehouse = [
+      "roles/bigquery.admin",
+      "roles/aiplatform.admin",
+      "roles/cloudfunctions.admin",
+      "roles/dataform.admin",
+      "roles/datalineage.viewer",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountTokenCreator",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.configWriter",
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/run.invoker",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/storage.admin",
+      "roles/workflows.admin"
+    ]
+    scheduled_queries = [
+      "roles/bigquery.admin",
+      "roles/aiplatform.admin",
+      "roles/cloudfunctions.admin",
+      "roles/dataform.admin",
+      "roles/datalineage.viewer",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountTokenCreator",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.configWriter",
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/run.invoker",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/storage.admin",
+      "roles/workflows.admin"
+    ]
+    udf = [
+      "roles/bigquery.admin",
+      "roles/aiplatform.admin",
+      "roles/cloudfunctions.admin",
+      "roles/dataform.admin",
+      "roles/datalineage.viewer",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountTokenCreator",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.configWriter",
+      "roles/resourcemanager.projectIamAdmin",
+      "roles/run.invoker",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/storage.admin",
+      "roles/workflows.admin"
+    ]
+  }
+
+  int_required_roles = tolist(toset(flatten(values(local.per_module_roles))))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -18,19 +18,8 @@ locals {
   per_module_roles = {
     root = [
       "roles/bigquery.admin",
-      "roles/aiplatform.admin",
-      "roles/cloudfunctions.admin",
-      "roles/dataform.admin",
-      "roles/datalineage.viewer",
       "roles/iam.serviceAccountAdmin",
-      "roles/iam.serviceAccountTokenCreator",
-      "roles/iam.serviceAccountUser",
-      "roles/logging.configWriter",
       "roles/resourcemanager.projectIamAdmin",
-      "roles/run.invoker",
-      "roles/serviceusage.serviceUsageAdmin",
-      "roles/storage.admin",
-      "roles/workflows.admin"
     ]
     authorization = [
       "roles/bigquery.admin",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -13,6 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+locals {
+  per_module_services = {
+    root = [
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "bigquery.googleapis.com",
+      "bigquerystorage.googleapis.com",
+      "bigqueryconnection.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+    ]
+    authorization = [
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "bigquery.googleapis.com",
+      "bigquerystorage.googleapis.com",
+      "bigqueryconnection.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+    ]
+    data_warehouse = [
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "bigquery.googleapis.com",
+      "bigquerystorage.googleapis.com",
+      "bigqueryconnection.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+    ]
+    scheduled_queries = [
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "bigquery.googleapis.com",
+      "bigquerystorage.googleapis.com",
+      "bigqueryconnection.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+    ]
+    udf = [
+      "cloudkms.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "bigquery.googleapis.com",
+      "bigquerystorage.googleapis.com",
+      "bigqueryconnection.googleapis.com",
+      "serviceusage.googleapis.com",
+      "iam.googleapis.com",
+    ]
+  }
+}
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
@@ -25,15 +74,7 @@ module "project" {
   billing_account         = var.billing_account
   default_service_account = "keep"
 
-  activate_apis = [
-    "cloudkms.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "bigquery.googleapis.com",
-    "bigquerystorage.googleapis.com",
-    "bigqueryconnection.googleapis.com",
-    "serviceusage.googleapis.com",
-    "iam.googleapis.com",
-  ]
+  activate_apis = tolist(toset(flatten(values(local.per_module_services))))
 }
 
 module "kms_keyring" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,9 +16,11 @@
 locals {
   per_module_services = {
     root = [
+      "iam.googleapis.com",
+      "cloudkms.googleapis.com",
       "cloudresourcemanager.googleapis.com",
       "bigquery.googleapis.com",
-      "iam.googleapis.com",
+      "bigquerystorage.googleapis.com",
     ]
     authorization = [
       "cloudkms.googleapis.com",

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,12 +16,8 @@
 locals {
   per_module_services = {
     root = [
-      "cloudkms.googleapis.com",
       "cloudresourcemanager.googleapis.com",
       "bigquery.googleapis.com",
-      "bigquerystorage.googleapis.com",
-      "bigqueryconnection.googleapis.com",
-      "serviceusage.googleapis.com",
       "iam.googleapis.com",
     ]
     authorization = [


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.

