### PR TITLE
feat: add table_constraints support for BigQuery tables

### DIFF
--- a/examples/multiple_tables/main.tf
+++ b/examples/multiple_tables/main.tf
@@ -38,6 +38,11 @@ module "bigquery" {
       range_partitioning = null,
       expiration_time    = null,
       clustering         = ["fullVisitorId", "visitId"],
+      table_constraints = {
+        primary_key = {
+          columns = ["fullVisitorId"]
+        }
+      },
       labels = {
         env      = "dev"
         billable = "true"

--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,33 @@ resource "google_bigquery_table" "main" {
     }
   }
 
+  dynamic "table_constraints" {
+    for_each = each.value["table_constraints"] != null ? [each.value["table_constraints"]] : []
+    content {
+      dynamic "primary_key" {
+        for_each = table_constraints.value["primary_key"] != null ? [table_constraints.value["primary_key"]] : []
+        content {
+          columns = primary_key.value["columns"]
+        }
+      }
+      dynamic "foreign_keys" {
+        for_each = table_constraints.value["foreign_keys"] != null ? table_constraints.value["foreign_keys"] : []
+        content {
+          name = foreign_keys.value["name"]
+          referenced_table {
+            project_id = foreign_keys.value["referenced_table"]["project_id"]
+            dataset_id = foreign_keys.value["referenced_table"]["dataset_id"]
+            table_id   = foreign_keys.value["referenced_table"]["table_id"]
+          }
+          column_references {
+            referencing_column = foreign_keys.value["column_references"]["referencing_column"]
+            referenced_column  = foreign_keys.value["column_references"]["referenced_column"]
+          }
+        }
+      }
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       encryption_configuration # managed by google_bigquery_dataset.main.default_encryption_configuration

--- a/test/integration/full/controls/big_query.rb
+++ b/test/integration/full/controls/big_query.rb
@@ -33,6 +33,7 @@ describe google_bigquery_table(project: "#{project_id}", dataset: "#{dataset_nam
   its('friendly_name') { should eq "#{tables[:foo][:friendly_name]}" }
   its('time_partitioning.type') { should eq 'DAY' }
   its('clustering') { should_not be nil }
+  its('table_constraints.primary_key.columns') { should include 'fullVisitorId' }
 end
 
 describe google_bigquery_table(project: "#{project_id}", dataset: "#{dataset_name}", name: "#{tables[:bar][:friendly_name]}") do

--- a/variables.tf
+++ b/variables.tf
@@ -143,6 +143,23 @@ variable "tables" {
     expiration_time     = optional(string, null),
     deletion_protection = optional(bool),
     labels              = optional(map(string), {}),
+    table_constraints = optional(object({
+      primary_key = optional(object({
+        columns = list(string),
+      })),
+      foreign_keys = optional(list(object({
+        name = optional(string),
+        referenced_table = object({
+          project_id = string,
+          dataset_id = string,
+          table_id   = string,
+        }),
+        column_references = object({
+          referencing_column = string,
+          referenced_column  = string,
+        }),
+      })), []),
+    })),
   }))
 }
 


### PR DESCRIPTION
Add support for primary_key and foreign_keys constraints on google_bigquery_table resources via the tables variable.

Update the multiple_tables example and integration test to exercise a primary_key constraint.