### PR TITLE
feat: add create_dataset variable to support existing datasets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,9 +26,18 @@ locals {
     "roles/bigquery.dataEditor" : "WRITER"
     "roles/bigquery.dataViewer" : "READER"
   }
+
+  dataset = var.create_dataset ? google_bigquery_dataset.main[0] : data.google_bigquery_dataset.main[0]
+}
+
+data "google_bigquery_dataset" "main" {
+  count      = var.create_dataset ? 0 : 1
+  dataset_id = var.dataset_id
+  project    = var.project_id
 }
 
 resource "google_bigquery_dataset" "main" {
+  count                           = var.create_dataset ? 1 : 0
   dataset_id                      = var.dataset_id
   friendly_name                   = var.dataset_name
   description                     = var.description
@@ -69,7 +78,7 @@ resource "google_bigquery_dataset" "main" {
 
 resource "google_bigquery_table" "main" {
   for_each                 = local.tables
-  dataset_id               = google_bigquery_dataset.main.dataset_id
+  dataset_id               = local.dataset.dataset_id
   friendly_name            = each.value["table_name"] != null ? each.value["table_name"] : each.key
   table_id                 = each.key
   description              = each.value["description"]
@@ -111,7 +120,7 @@ resource "google_bigquery_table" "main" {
 
 resource "google_bigquery_table" "view" {
   for_each            = local.views
-  dataset_id          = google_bigquery_dataset.main.dataset_id
+  dataset_id          = local.dataset.dataset_id
   friendly_name       = each.key
   table_id            = each.key
   description         = each.value["description"]
@@ -133,7 +142,7 @@ resource "google_bigquery_table" "view" {
 
 resource "google_bigquery_table" "materialized_view" {
   for_each            = local.materialized_views
-  dataset_id          = google_bigquery_dataset.main.dataset_id
+  dataset_id          = local.dataset.dataset_id
   friendly_name       = each.key
   table_id            = each.key
   description         = each.value["description"]
@@ -181,7 +190,7 @@ resource "google_bigquery_table" "materialized_view" {
 
 resource "google_bigquery_table" "external_table" {
   for_each            = local.external_tables
-  dataset_id          = google_bigquery_dataset.main.dataset_id
+  dataset_id          = local.dataset.dataset_id
   friendly_name       = each.key
   table_id            = each.key
   description         = each.value["description"]
@@ -238,7 +247,7 @@ resource "google_bigquery_table" "external_table" {
 
 resource "google_bigquery_routine" "routine" {
   for_each        = local.routines
-  dataset_id      = google_bigquery_dataset.main.dataset_id
+  dataset_id      = local.dataset.dataset_id
   routine_id      = each.key
   description     = each.value["description"]
   routine_type    = each.value["routine_type"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@
  */
 
 output "bigquery_dataset" {
-  value       = google_bigquery_dataset.main
+  value       = local.dataset
   description = "Bigquery dataset resource."
 }
 
@@ -35,7 +35,7 @@ output "bigquery_external_tables" {
 }
 
 output "project" {
-  value       = google_bigquery_dataset.main.project
+  value       = local.dataset.project
   description = "Project where the dataset and tables are created"
 }
 
@@ -105,7 +105,7 @@ output "routine_ids" {
 
 output "env_vars" {
   value = {
-    "BIGQUERY_DATASET"            = google_bigquery_dataset.main.dataset_id
+    "BIGQUERY_DATASET"            = local.dataset.dataset_id
     "BIGQUERY_TABLES"             = jsonencode([for table in google_bigquery_table.main : table.table_id])
     "BIGQUERY_VIEWS"              = jsonencode([for table in google_bigquery_table.view : table.table_id])
     "BIGQUERY_MATERIALIZED_VIEWS" = jsonencode([for table in google_bigquery_table.materialized_view : table.table_id])

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "dataset_id" {
   type        = string
 }
 
+variable "create_dataset" {
+  description = "Whether to create the BigQuery dataset. Set to false to use an existing dataset specified by dataset_id."
+  type        = bool
+  default     = true
+}
+
 variable "dataset_name" {
   description = "Friendly name for the dataset being provisioned."
   type        = string


### PR DESCRIPTION
Add a boolean `create_dataset` variable (default: true) that allows the module to manage tables in an existing BigQuery dataset instead of always creating one. When set to false, a data source is used to look up the existing dataset by dataset_id, preserving all outputs and dependency ordering.