### PR TITLE
fix: deal with require_partition_filter deprecation warning

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,16 @@ output "bigquery_dataset" {
 }
 
 output "bigquery_tables" {
-  value       = google_bigquery_table.main
+  value = {
+    for table_name, table in google_bigquery_table.main :
+    table_name => {
+      id            = table.id
+      table_id      = table.table_id
+      friendly_name = table.friendly_name
+      project       = table.project
+      dataset_id    = table.dataset_id
+    }
+  }
   description = "Map of bigquery table resources being provisioned."
 }
 


### PR DESCRIPTION
`require_partition_filter` in `time_partitioning` block is [marked deprecated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#require_partition_filter-3) however, since `bigquery_tables` output spits out entire object, terraform complains on plan/apply:

```
│ Warning: Deprecated value used
│ 
│   on .terraform/modules/some_data/outputs.tf line 23, in output "bigquery_tables":
│   23:   value       = google_bigquery_table.main
│ 
│   The deprecation originates from module.some_data.google_bigquery_table.main["some_table"].time_partitioning[0].require_partition_filter
│ 
│ This field is deprecated and will be removed in a future major release;
│ please use the top level field with the same name instead.
│ 
│ (and 18 more similar warnings elsewhere)
```

Not quite sure if the right approach is to just wait it out, or in fact use only the attributes generally needed for output as proposed in this PR.